### PR TITLE
get input to match correct exacutable

### DIFF
--- a/bigconfig
+++ b/bigconfig
@@ -1,0 +1,10 @@
+SodaCost 2 # blah
+NumStudents 4
+MaxPurchases 8
+NumVendingMachines 2
+MaxStockPerFlavour 5
+MaxShippedPerFlavour 3
+TimeBetweenShipments 3
+GroupoffDelay 10
+ParentalDelay 2 
+NumCouriers 3

--- a/diff.py
+++ b/diff.py
@@ -18,30 +18,51 @@ def diff(a, b):
 	print()   
 
 resultsMap = {}
+
+resList = []
+correctList = []
 for i in range(0, times):
 	correctRes = subprocess.run(["./soda_correct", configfile, seed], stdout=subprocess.PIPE).stdout.decode('utf-8')
 	correctRes = "\n".join(correctRes.split('\n')[1:])
 
-	if correctRes in resultsMap:
-		resultsMap[correctRes][1] += 1
-	else:
-		resultsMap[correctRes] = [0, 1]
+	# if correctRes in resultsMap:
+	# 	resultsMap[correctRes][1] += 1
+	# else:
+	# 	resultsMap[correctRes] = [0, 1]
 
 	myRes = subprocess.run(["./soda", configfile, seed], stdout=subprocess.PIPE).stdout.decode('utf-8')
-	if myRes in resultsMap:
-		resultsMap[myRes][0] += 1
-	else:
-		resultsMap[myRes] = [1,0]
+	# if myRes in resultsMap:
+	# 	resultsMap[myRes][0] += 1
+	# else:
+	# 	resultsMap[myRes] = [1,0]
 
 	if correctRes != myRes:
 		for correct, mine in itertools.zip_longest(correctRes.split("\n"), myRes.split("\n"), fillvalue=""):
-			print(correct)
-			print(mine)
+			for i, v in enumerate(correct.split("\t")):
+				if len(v) == 0:
+					continue
+
+				while i > len(correctList)-1:
+					correctList.append([])
+				correctList[i].append(v)
+
+			for i, v in enumerate(mine.split("\t")):
+				if len(v) == 0:
+					continue
+				while i > len(resList)-1:
+					resList.append([])
+				resList[i].append(v)
+			print("correct:\t", correct)
+			print("output :\t", mine)
 			print("\n\n")
 
+	for correct, mine in itertools.zip_longest(correctList, resList, fillvalue=""):
+		print("correct:\t", correct)
+		print("output :\t",mine)
+		print("\n")
 	# diff(correctRes, myRes)
 
 
-for key in resultsMap:
+# for key in resultsMap:
 	# print(key)
-	print(resultsMap[key])
+	# print(resultsMap[key])

--- a/diff.py
+++ b/diff.py
@@ -1,0 +1,47 @@
+import sys
+import subprocess
+import difflib
+import itertools
+
+configfile = sys.argv[1]
+seed = sys.argv[2]
+times = 1
+
+def diff(a, b):
+	print('{} => {}'.format(a,b))  
+	for i,s in enumerate(difflib.ndiff(a, b)):
+		if s[0]==' ': continue
+		elif s[0]=='-':
+			print(u'Delete "{}" from position {}'.format(s[-1],i))
+		elif s[0]=='+':
+			print(u'Add "{}" to position {}'.format(s[-1],i))    
+	print()   
+
+resultsMap = {}
+for i in range(0, times):
+	correctRes = subprocess.run(["./soda_correct", configfile, seed], stdout=subprocess.PIPE).stdout.decode('utf-8')
+	correctRes = "\n".join(correctRes.split('\n')[1:])
+
+	if correctRes in resultsMap:
+		resultsMap[correctRes][1] += 1
+	else:
+		resultsMap[correctRes] = [0, 1]
+
+	myRes = subprocess.run(["./soda", configfile, seed], stdout=subprocess.PIPE).stdout.decode('utf-8')
+	if myRes in resultsMap:
+		resultsMap[myRes][0] += 1
+	else:
+		resultsMap[myRes] = [1,0]
+
+	if correctRes != myRes:
+		for correct, mine in itertools.zip_longest(correctRes.split("\n"), myRes.split("\n"), fillvalue=""):
+			print(correct)
+			print(mine)
+			print("\n\n")
+
+	# diff(correctRes, myRes)
+
+
+for key in resultsMap:
+	# print(key)
+	print(resultsMap[key])

--- a/groupoff.h
+++ b/groupoff.h
@@ -8,6 +8,7 @@ _Task Groupoff {
 	Printer &prt;
 	unsigned int numStudents, sodaCost, groupoffDelay, waiting = 0;
 	WATCard::FWATCard *giftCards;
+	WATCard **fulfilled;
 	int *studentIndex;
 	void main();
   public:

--- a/main.cc
+++ b/main.cc
@@ -44,7 +44,7 @@ int main( int argc, char * argv[] ) {
 
     Printer printer(configParms.numStudents, configParms.numVendingMachines, configParms.numCouriers); 
     Bank bank(configParms.numStudents);
-    Parent parent(printer, bank, configParms.numStudents, configParms.parentalDelay);
+    Parent * parent = new Parent(printer, bank, configParms.numStudents, configParms.parentalDelay);
     WATCardOffice *office = new WATCardOffice(printer, bank, configParms.numCouriers);
     Groupoff *groupoff = new Groupoff(printer, configParms.numStudents, configParms.sodaCost, configParms.groupoffDelay);
 
@@ -76,10 +76,9 @@ int main( int argc, char * argv[] ) {
     }
     
     delete [] students;
-
+    delete parent;
     delete office;
     delete groupoff;
-
     delete bp;
     delete ns;
     for(unsigned int i=0; i<configParms.numVendingMachines; i++){

--- a/main.cc
+++ b/main.cc
@@ -44,20 +44,18 @@ int main( int argc, char * argv[] ) {
 
     Printer printer(configParms.numStudents, configParms.numVendingMachines, configParms.numCouriers); 
     Bank bank(configParms.numStudents);
-    Parent * parent = new Parent(printer, bank, configParms.numStudents, configParms.parentalDelay);
-    WATCardOffice *office = new WATCardOffice(printer, bank, configParms.numCouriers);
-    Groupoff *groupoff = new Groupoff(printer, configParms.numStudents, configParms.sodaCost, configParms.groupoffDelay);
-
-    NameServer * ns = new NameServer(printer, configParms.numVendingMachines, configParms.numStudents);
+    Parent parent(printer, bank, configParms.numStudents, configParms.parentalDelay);
+    WATCardOffice office(printer, bank, configParms.numCouriers);
+    Groupoff groupoff(printer, configParms.numStudents, configParms.sodaCost, configParms.groupoffDelay);
+    NameServer ns(printer, configParms.numVendingMachines, configParms.numStudents);
     VendingMachine **vms = new VendingMachine*[configParms.numVendingMachines];
 
     for(unsigned int i=0; i<configParms.numVendingMachines; i++){
-        vms[i] = new VendingMachine(printer, *ns, i, configParms.sodaCost);
+        vms[i] = new VendingMachine(printer, ns, i, configParms.sodaCost);
     }
 
-
     BottlingPlant * bp = new BottlingPlant(
-        printer, *ns,
+        printer, ns,
         configParms.numVendingMachines,
         configParms.maxShippedPerFlavour,
         configParms.maxStockPerFlavour,
@@ -67,7 +65,7 @@ int main( int argc, char * argv[] ) {
     Student **students = new Student*[configParms.numStudents];
 
     for (unsigned int i = 0; i < configParms.numStudents; i ++) {
-        students[i] = new Student(printer, *ns, *office, *groupoff, i, configParms.maxPurchases);
+        students[i] = new Student(printer, ns, office, groupoff, i, configParms.maxPurchases);
     }
 
 
@@ -76,14 +74,9 @@ int main( int argc, char * argv[] ) {
     }
     
     delete [] students;
-    delete parent;
-    delete office;
-    delete groupoff;
     delete bp;
-    delete ns;
     for(unsigned int i=0; i<configParms.numVendingMachines; i++){
         delete vms[i];
     }
     delete [] vms;
-    
 } // main

--- a/main.cc
+++ b/main.cc
@@ -53,7 +53,6 @@ int main( int argc, char * argv[] ) {
 
     for(unsigned int i=0; i<configParms.numVendingMachines; i++){
         vms[i] = new VendingMachine(printer, *ns, i, configParms.sodaCost);
-        ns->VMregister(vms[i]);
     }
 
 

--- a/parent.cc
+++ b/parent.cc
@@ -8,8 +8,8 @@ void Parent::main(){
     _Accept(~Parent) break;
     _Else {
       yield(parentalDelay);
-      unsigned int recipient = mprng(numStudents - 1);
       unsigned int amount = mprng(1,3);
+      unsigned int recipient = mprng(numStudents - 1);
       bank.deposit(recipient, amount);
       prt.print(Printer::Parent, 'D', recipient, amount);
     }

--- a/printer.cc
+++ b/printer.cc
@@ -94,10 +94,10 @@ void Printer::flush_name(){
 			cout<<states[3].state<<states[3].value1;
 			break;
 		case 'N':
-			cout<<states[3].state<<states[3].value1<<","<<states[2].value2;
+			cout<<states[3].state<<states[3].value1<<","<<states[3].value2;
 			break;
 		default:
-			throw "unknown state for name server "+states[2].state;
+			throw "unknown state for name server "+states[3].state;
 	}
 }
 void Printer::flush_truck(){

--- a/simpleconfig
+++ b/simpleconfig
@@ -1,0 +1,10 @@
+SodaCost 2 # blah
+NumStudents 1
+MaxPurchases 3
+NumVendingMachines 1
+MaxStockPerFlavour 5
+MaxShippedPerFlavour 3
+TimeBetweenShipments 3
+GroupoffDelay 10
+ParentalDelay 2 
+NumCouriers 1

--- a/small2.config
+++ b/small2.config
@@ -1,0 +1,10 @@
+SodaCost 2 # blah
+NumStudents 2
+MaxPurchases 2
+NumVendingMachines 3
+MaxStockPerFlavour 5
+MaxShippedPerFlavour 3
+TimeBetweenShipments 3
+GroupoffDelay 10
+ParentalDelay 2 
+NumCouriers 1

--- a/student.cc
+++ b/student.cc
@@ -1,6 +1,7 @@
 #include "student.h"
 #include "watcard_office.h"
 #include "MPRNG.h"
+
 extern MPRNG mprng;
 Student::Student( Printer & prt, NameServer & nameServer, WATCardOffice & cardOffice, Groupoff & groupoff,
                  unsigned int id, unsigned int maxPurchases ) : prt(prt), nameServer(nameServer), cardOffice(cardOffice), groupoff(groupoff), id(id), maxPurchases(maxPurchases) {}
@@ -34,6 +35,7 @@ void Student::main() {
                     } catch (VendingMachine::Stock &) {
                         machine = nameServer.getMachine(id);
                         prt.print(Printer::Student, id, 'V', machine -> getId());
+                        break;
                     }
                 } or _Select(watcard) {
                     try {
@@ -48,6 +50,7 @@ void Student::main() {
                     } catch (VendingMachine::Stock &) {
                         machine = nameServer.getMachine(id);
                         prt.print(Printer::Student, id, 'V', machine -> getId());
+                        break;
                     } catch (VendingMachine::Funds &) {
                         watcard = cardOffice.transfer(id, machine -> cost() + 5, watcard());
                         break;

--- a/vending.cc
+++ b/vending.cc
@@ -1,8 +1,10 @@
 #include "vending.h"
 #include "printer.h"
+#include "nameserver.h"
 
 VendingMachine::VendingMachine( Printer & prt, NameServer & nameServer, unsigned int id, unsigned int sodaCost ):
 prt{prt}, nameServer{nameServer}, id{id}, sodaCost{sodaCost} {
+	nameServer.VMregister(this);
 	prt.print(Printer::Vending, id, 'S', sodaCost);
 }
 
@@ -13,6 +15,12 @@ VendingMachine::~VendingMachine(){
 // A student calls buy to obtain one of their favourite sodas.
 // TODO: A flag variable is necessary to know when to raise Funds, Stock or Free on the correct task stack?
 void VendingMachine::buy(VendingMachine::Flavours flavour, WATCard & card ){
+	//The vending machine cannot accept buy calls during restocking
+	if (restocking){
+		restockingCond.wait();
+	}
+
+
 	// Check first if the student has sufficient funds to purchase the soda
 	if (card.getBalance() < sodaCost) {
 		throw VendingMachine::Funds();
@@ -37,10 +45,16 @@ void VendingMachine::buy(VendingMachine::Flavours flavour, WATCard & card ){
 }
 
 unsigned int * VendingMachine::inventory(){
+    prt.print(Printer::Vending, id, 'r');
+	restocking = true;
 	return (unsigned int * )sodaStock;
 }
 void VendingMachine::restocked(){
-
+    prt.print(Printer::Vending, id, 'R');
+	restocking = false;
+	while(!restockingCond.empty()){
+		restockingCond.signal();
+	}
 }
 _Nomutex unsigned int VendingMachine::cost() const{
 	return sodaCost;
@@ -52,5 +66,4 @@ _Nomutex unsigned int VendingMachine::getId() const{
 
 
 void VendingMachine::main() {
-
 }

--- a/vending.h
+++ b/vending.h
@@ -14,6 +14,8 @@ _Task VendingMachine {
 	NameServer & nameServer;
 	unsigned int id, sodaCost;
 	unsigned int sodaStock[4] = {0,0,0,0};
+	bool restocking = false;
+	uCondition restockingCond;
 
   public:
 	enum Flavours { Moist, BBQ, Human, Meat }; 				// flavours of soda (YOU DEFINE)

--- a/watcard_office.cc
+++ b/watcard_office.cc
@@ -94,10 +94,11 @@ void WATCardOffice::Courier::main() {
 			break;
 		} _Else{
 			Job *job = office.requestWork();
-
 			if(done){
 				break;
 			}
+			prt.print(Printer::Courier, 't', job -> args.sid, job -> args.amount);
+
 			bank.withdraw(job -> args.sid, job -> args.amount);
 
 			job -> args.watcard -> deposit(job -> args.amount);
@@ -106,7 +107,6 @@ void WATCardOffice::Courier::main() {
 				job -> result.exception(new Lost());
 				delete job -> args.watcard;
 			} else {
-				prt.print(Printer::Courier, 't', job -> args.sid, job -> args.amount);
 				job -> result.delivery(job -> args.watcard);
 				prt.print(Printer::Courier, 'T', job -> args.sid, job -> args.amount);
 			}

--- a/watcard_office.cc
+++ b/watcard_office.cc
@@ -115,5 +115,5 @@ void WATCardOffice::Courier::main() {
 		}
 	}
 
-	prt.print(Printer::Courier, 'F',id );
+	prt.print(Printer::Courier, id, 'F');
 }

--- a/watcard_office.cc
+++ b/watcard_office.cc
@@ -69,6 +69,13 @@ WATCardOffice::Job * WATCardOffice::requestWork() {
 	if (pendingJobs.empty()) {
 		jobReady.wait();
 	}
+	// we may be woken up by the destructor signalling shutdown & no more jobs
+	// in which case, the queue would be empty. in this case, don't print anything
+	// and just return a nullptr
+	if (pendingJobs.empty()){
+		return nullptr;
+	}
+
 	Job *nextJob = pendingJobs.front();
 	pendingJobs.pop();
 	prt.print(Printer::WATCardOffice, 'W');

--- a/watcard_office.h
+++ b/watcard_office.h
@@ -20,13 +20,14 @@ _Task WATCardOffice {
 	};
 
 	_Task Courier { 
+		unsigned int id;
 		WATCardOffice &office;
 		Bank &bank;
 		Printer &prt;
 		void main();
 	public:
 		bool done=false;
-		Courier(WATCardOffice &office, Bank &bank, Printer &prt): office(office), bank(bank), prt(prt) {}
+		Courier(unsigned int id, WATCardOffice &office, Bank &bank, Printer &prt): id(id), office(office), bank(bank), prt(prt) {}
 	};					// communicates with bank
 
 	Printer &prt;


### PR DESCRIPTION
so far it looks like the ORDER of when things happen is matches up, but when EXACTLY things are printed don't, and some RNG dependent values differ.

e.g.
python3 diff.py simpleconfig 1 gives

```
Parent	Gropoff	WATOff	Names	Truck	Plant	Stud0	Mach0	Cour0
Parent	Gropoff	WATOff	Names	Truck	Plant	Stud0	Mach0	Cour0



*******	*******	*******	*******	*******	*******	*******	*******	*******
*******	*******	*******	*******	*******	*******	*******	*******	*******



S	S	S	S					S
S	S	S	S					S



D0,2			R0		S	S3,1	S2
D0,2		W	R0		S	S3,1	S2



D0,2		C0,5	N0,0	S	G7	V0		t0,5
D0,2		C0,5	N0,5	S	G7	V0



D0,3		W		P7				T0,5
D0,2								t0,5



				d0,7
		W		P7	P			T0,5



				U0,13
				d0,7			r



D0,2				D0,0	P		r
				U0,13



D0,2					G7		R
				D0,0			R



D0,3	D2
						B3,3	B3,2



	F					B3,3
D0,2		F				F



D0,2						F	B3,2
D0,3					G6			F



D0,3				F	F
D0,3	D2



D0,1							F
D0,2	F



D0,3			F
D0,1				F	F



D0,2
D0,1			F



D0,2		F						F
D0,1							F



D0,1
D0,2



F
F



***********************
***********************
```

(line by line comparison of compiled vs correct executable)
